### PR TITLE
Included category_order plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ blog.code-workspace
 *.exe
 *.o
 *.so
-plugins/category_order


### PR DESCRIPTION
To resolve [Issue 1](https://github.com/mamcmanus/brutalistpelican/issues/1#issue-391522911) if you desire; also edited .gitignore to watch /plugins/category_order (so maybe this was an intentional omission of the plugin?)

Either way, thanks for the theme--beautiful!